### PR TITLE
Add free automated testing with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
As a thank you for the nice work on TheAlgorithms/Python#1042...

These test will run on each update to the code.

You will need to log into https://travis-ci.org/mahbubcseju using your github credentials to turn on this free service.  This is a simple config (but it still catches one issue on Python 3).  To see a more complex config, see https://github.com/TheAlgorithms/Python/blob/master/.travis.yml

Test results: https://travis-ci.com/cclauss/DroneFlight/jobs/217505294#L192